### PR TITLE
Dynamic Injection

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,19 @@
 Upgrading
 =========
 
+#### 2.1.0
+
+The `Container::inject()` method is now `public`, so that auto-wiring scenarios can be implemented
+without extending the `Container` itself, which should help improve separation of concerns.
+
+Also, this method will now throw an `InvalidArgumentException` on attempted override of an existing
+component - this is *technically* a minor BC break, since, previously, it did not throw under this
+condition; however, you *should* have been testing with `has()` before injecting any component at
+run-time, and hopefully you were, as replacing an active dependency could have otherwise resulted
+in very strange side-effects and bugs.
+
+This method *should* have been throwing, and, hence, we regard this change as a bug-fix.
+
 #### 2.0.0
 
 Version 2 introduces some BC breaks from version 1.x, as described below.

--- a/src/Container.php
+++ b/src/Container.php
@@ -216,13 +216,23 @@ class Container extends Configuration implements ContainerInterface, FactoryInte
     /**
      * Dynamically inject a component into this Container.
      *
-     * Enables classes that extend `Container` to dynamically inject components (to implement "auto-wiring")
+     * Enables implementation of "auto-wiring" patterns, where missing components are injected
+     * at run-time into a live `Container` instance.
      *
-     * @param string $name
+     * You should always test with {@see has()} prior to injecting a component - attempting to
+     * override an existing component will generate an exception.
+     *
+     * @throws InvalidArgumentException if the specified component has already been defined
+     *
+     * @param string $name component name
      * @param mixed  $value
      */
-    protected function inject($name, $value)
+    public function inject($name, $value)
     {
+        if ($this->has($name)) {
+            throw new InvalidArgumentException("attempted override of existing component: {$name}");
+        }
+
         $this->values[$name] = $value;
         $this->active[$name] = true;
     }

--- a/test/fixtures.php
+++ b/test/fixtures.php
@@ -79,28 +79,3 @@ class TestProvider implements ProviderInterface
         });
     }
 }
-
-class CustomContainerFactory extends ContainerFactory
-{
-    public function createContainer()
-    {
-        return new CustomContainer($this);
-    }
-}
-
-class CustomContainer extends Container
-{
-    /**
-     * @param $name
-     *
-     * @return mixed
-     */
-    public function getAutoWired($name)
-    {
-        if (! $this->has($name)) {
-            $this->inject($name, $this->create($name));
-        }
-
-        return $this->get($name);
-    }
-}

--- a/test/test.php
+++ b/test/test.php
@@ -365,17 +365,31 @@ test(
 );
 
 test(
-    'can implement "auto-wiring" by using the internal inject() method',
+    'can implement "auto-wiring" by using the inject() method',
     function () {
-        $factory = new CustomContainerFactory();
+        $factory = new ContainerFactory();
 
         $container = $factory->createContainer();
 
-        ok($container->getAutoWired(Bar::class) instanceof Bar);
+        eq($container->has(Bar::class), false);
 
-        ok($container->has(Bar::class));
+        $instance = new Bar();
 
-        ok($container->get(Bar::class) instanceof Bar);
+        $container->inject(Bar::class, $instance);
+
+        eq($container->has(Bar::class), true);
+
+        eq($container->isActive(Bar::class), true);
+
+        eq($container->get(Bar::class), $instance);
+
+        expect(
+            InvalidArgumentException::class,
+            "should throw on attempted overrride",
+            function () use ($container) {
+                $container->inject(Bar::class, new Bar());
+            }
+        );
     }
 );
 


### PR DESCRIPTION
This PR proposes to make the protected `inject()` method public, so that "auto-wiring" scenarios can be implemented by composition rather than inheritance.

Please see documentation and test updates for details.
