### PR TITLE
2.0.1

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,12 +3,12 @@ Upgrading
 
 #### 2.0.1
 
-This release changes the PSR-11 dependency from the deprecated `container-interop/container-interop`
-to `psr/container` - these interfaces are identical, so while this can cause a dependency issue (if
-you inherited the dependency rather than declaring it!) this is regarded as a non-breaking change.
+This release provides *forward* compatibility with `psr/container`, and backwards compatibility with
+the deprecated `container-interop/container-interop` package.
 
-If this release causes problems for you, please see [this issue](https://github.com/mindplay-dk/unbox/issues/11)
-- the upgrade from the deprecated to the final package is a simple search and replace in your project.
+Version 3.0 will most likely remove backwards compatibility with `container-interop/container-interop`,
+but as that is a breaking change, this update merely adds forward compatibility with the final PSR-11
+package.
 
 #### 2.0.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,7 +3,7 @@ Upgrading
 
 #### 2.0.1
 
-This release provides *forward* compatibility with `psr/container`, and backwards compatibility with
+This release improves *forward* compatibility with `psr/container`, and backwards compatibility with
 the deprecated `container-interop/container-interop` package.
 
 Version 3.0 will most likely remove backwards compatibility with `container-interop/container-interop`,

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,15 @@
 Upgrading
 =========
 
+#### 2.0.1
+
+This release changes the PSR-11 dependency from the deprecated `container-interop/container-interop`
+to `psr/container` - these interfaces are identical, so while this can cause a dependency issue (if
+you inherited the dependency rather than declaring it!) this is regarded as a non-breaking change.
+
+If this release causes problems for you, please see [this issue](https://github.com/mindplay-dk/unbox/issues/11)
+- the upgrade from the deprecated to the final package is a simple search and replace in your project.
+
 #### 2.0.0
 
 Version 2 introduces some BC breaks from version 1.x, as described below.

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "php": ">=5.5",
-        "psr/container": "^1.0"
+        "psr/container": "^1.0",
+        "container-interop/container-interop": "^1.2"
     },
     "require-dev": {
         "mindplay/benchpress": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "container-interop/container-interop": "~1.0"
+        "psr/container": "^1.0"
     },
     "require-dev": {
         "mindplay/benchpress": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,39 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d134881b047559959241ff1a7412f3c4",
+    "content-hash": "9659771c245584b8c6c1638c8ec6a21d",
     "packages": [
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "homepage": "https://github.com/container-interop/container-interop",
+            "time": "2017-02-14T19:40:03+00:00"
+        },
         {
             "name": "psr/container",
             "version": "1.0.0",
@@ -57,37 +88,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "container-interop/container-interop",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "shasum": ""
-            },
-            "require": {
-                "psr/container": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Container\\": "src/Interop/Container/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "homepage": "https://github.com/container-interop/container-interop",
-            "time": "2017-02-14T19:40:03+00:00"
-        },
         {
             "name": "mindplay/benchpress",
             "version": "dev-master",
@@ -165,7 +165,7 @@
                 }
             ],
             "description": "Yeah, testies: a lightweight library for quick, simple unit-testing",
-            "time": "2017-06-02T13:06:21+00:00"
+            "time": "2017-06-02 13:06:21"
         },
         {
             "name": "php-di/invoker",

--- a/composer.lock
+++ b/composer.lock
@@ -4,22 +4,75 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a3e96edeaed9202f91911a619e8f4444",
-    "content-hash": "e318895142d5e367bb3100a1f42111d4",
+    "content-hash": "d134881b047559959241ff1a7412f3c4",
     "packages": [
         {
-            "name": "container-interop/container-interop",
-            "version": "1.1.0",
+            "name": "psr/container",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e"
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/fc08354828f8fd3245f77a66b9e23a6bca48297e",
-                "reference": "fc08354828f8fd3245f77a66b9e23a6bca48297e",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
                 "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
             },
             "type": "library",
             "autoload": {
@@ -32,10 +85,9 @@
                 "MIT"
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "time": "2014-12-30 15:22:37"
-        }
-    ],
-    "packages-dev": [
+            "homepage": "https://github.com/container-interop/container-interop",
+            "time": "2017-02-14T19:40:03+00:00"
+        },
         {
             "name": "mindplay/benchpress",
             "version": "dev-master",
@@ -78,12 +130,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mindplay-dk/testies.git",
-                "reference": "272516fe2232929032e09002f380437a23aa3feb"
+                "reference": "583c2078e24cb506a698f0d78bbbd5fba6323125"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mindplay-dk/testies/zipball/272516fe2232929032e09002f380437a23aa3feb",
-                "reference": "272516fe2232929032e09002f380437a23aa3feb",
+                "url": "https://api.github.com/repos/mindplay-dk/testies/zipball/583c2078e24cb506a698f0d78bbbd5fba6323125",
+                "reference": "583c2078e24cb506a698f0d78bbbd5fba6323125",
                 "shasum": ""
             },
             "require-dev": {
@@ -113,7 +165,7 @@
                 }
             ],
             "description": "Yeah, testies: a lightweight library for quick, simple unit-testing",
-            "time": "2016-05-09 09:41:04"
+            "time": "2017-06-02T13:06:21+00:00"
         },
         {
             "name": "php-di/invoker",
@@ -156,30 +208,32 @@
                 "invoke",
                 "invoker"
             ],
-            "time": "2016-07-14 13:09:58"
+            "time": "2016-07-14T13:09:58+00:00"
         },
         {
             "name": "php-di/php-di",
-            "version": "5.3.0",
+            "version": "5.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-DI/PHP-DI.git",
-                "reference": "854a6d8f54e2146f0a34f0a28f0adea688b634a3"
+                "reference": "3f9255659595f3e289f473778bb6c51aa72abbbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-DI/PHP-DI/zipball/854a6d8f54e2146f0a34f0a28f0adea688b634a3",
-                "reference": "854a6d8f54e2146f0a34f0a28f0adea688b634a3",
+                "url": "https://api.github.com/repos/PHP-DI/PHP-DI/zipball/3f9255659595f3e289f473778bb6c51aa72abbbd",
+                "reference": "3f9255659595f3e289f473778bb6c51aa72abbbd",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "~1.0",
+                "container-interop/container-interop": "~1.2",
                 "php": ">=5.5.0",
-                "php-di/invoker": "^1.1.1",
-                "php-di/phpdoc-reader": "^2.0.1"
+                "php-di/invoker": "^1.3.2",
+                "php-di/phpdoc-reader": "^2.0.1",
+                "psr/container": "~1.0"
             },
             "provide": {
-                "container-interop/container-interop-implementation": "^1.0"
+                "container-interop/container-interop-implementation": "^1.0",
+                "psr/container-implementation": "^1.0"
             },
             "replace": {
                 "mnapoli/php-di": "*"
@@ -189,6 +243,7 @@
                 "doctrine/cache": "~1.4",
                 "mnapoli/phpunit-easymock": "~0.2.0",
                 "ocramius/proxy-manager": "~1.0|~2.0",
+                "phpbench/phpbench": "@dev",
                 "phpunit/phpunit": "~4.5"
             },
             "suggest": {
@@ -216,7 +271,7 @@
                 "dependency injection",
                 "di"
             ],
-            "time": "2016-06-01 17:23:41"
+            "time": "2017-12-03T08:20:27+00:00"
         },
         {
             "name": "php-di/phpdoc-reader",
@@ -253,7 +308,7 @@
                 "phpdoc",
                 "reflection"
             ],
-            "time": "2015-11-29 10:34:25"
+            "time": "2015-11-29T10:34:25+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -315,20 +370,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -362,7 +417,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -403,20 +458,20 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "1.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
                 "shasum": ""
             },
             "require": {
@@ -452,7 +507,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2017-12-04T08:55:13+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -498,7 +553,7 @@
                 "container",
                 "dependency injection"
             ],
-            "time": "2015-07-30 09:57:46"
+            "time": "2015-07-30T09:57:46+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -548,7 +603,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/version",
@@ -583,7 +638,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         }
     ],
     "aliases": [],

--- a/src/Container.php
+++ b/src/Container.php
@@ -31,6 +31,8 @@ class Container extends Configuration implements ContainerInterface, FactoryInte
                 __CLASS__                 => $this,
                 ContainerInterface::class => $this,
                 FactoryInterface::class   => $this,
+                // backwards compatibility for legacy PSR-11 package:
+                'Interop\\Container\\ContainerInterface' => $this,
             ];
     }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -2,7 +2,8 @@
 
 namespace mindplay\unbox;
 
-use Psr\Container\ContainerInterface;
+use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface as PsrContainerInterface;
 use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionFunction;
@@ -27,12 +28,11 @@ class Container extends Configuration implements ContainerInterface, FactoryInte
 
         $this->values = $this->values +
             [
-                get_class($this)          => $this,
-                __CLASS__                 => $this,
-                ContainerInterface::class => $this,
-                FactoryInterface::class   => $this,
-                // backwards compatibility for legacy PSR-11 package:
-                'Interop\\Container\\ContainerInterface' => $this,
+                get_class($this)             => $this,
+                __CLASS__                    => $this,
+                PsrContainerInterface::class => $this,
+                ContainerInterface::class    => $this,
+                FactoryInterface::class      => $this,
             ];
     }
 
@@ -57,7 +57,7 @@ class Container extends Configuration implements ContainerInterface, FactoryInte
                 $params = $this->resolve($reflection->getParameters(), $this->factory_map[$name]);
 
                 $this->values[$name] = call_user_func_array($factory, $params);
-            } elseif (!array_key_exists($name, $this->values)) {
+            } elseif (! array_key_exists($name, $this->values)) {
                 throw new NotFoundException($name);
             }
 
@@ -134,13 +134,13 @@ class Container extends Configuration implements ContainerInterface, FactoryInte
      */
     public function create($class_name, $map = [])
     {
-        if (!class_exists($class_name)) {
+        if (! class_exists($class_name)) {
             throw new InvalidArgumentException("unable to create component: {$class_name}");
         }
 
         $reflection = new ReflectionClass($class_name);
 
-        if (!$reflection->isInstantiable()) {
+        if (! $reflection->isInstantiable()) {
             throw new InvalidArgumentException("unable to create instance of abstract class: {$class_name}");
         }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -4,7 +4,6 @@ namespace mindplay\unbox;
 
 use Interop\Container\ContainerInterface;
 use Psr\Container\ContainerInterface as PsrContainerInterface;
-use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionFunction;
 use ReflectionParameter;
@@ -43,7 +42,6 @@ class Container extends Configuration implements ContainerInterface, FactoryInte
      *
      * @return mixed
      *
-     * @throws ContainerException
      * @throws NotFoundException
      */
     public function get($name)
@@ -131,6 +129,8 @@ class Container extends Configuration implements ContainerInterface, FactoryInte
      * @param mixed|mixed[] $map        mixed list/map of parameter values (and/or boxed values)
      *
      * @return mixed
+     *
+     * @throws InvalidArgumentException
      */
     public function create($class_name, $map = [])
     {
@@ -165,7 +165,6 @@ class Container extends Configuration implements ContainerInterface, FactoryInte
      * @return array parameters
      *
      * @throws ContainerException
-     * @throws NotFoundException
      */
     protected function resolve(array $params, $map, $safe = true)
     {

--- a/src/Container.php
+++ b/src/Container.php
@@ -2,7 +2,7 @@
 
 namespace mindplay\unbox;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionFunction;

--- a/src/ContainerException.php
+++ b/src/ContainerException.php
@@ -10,6 +10,6 @@ use Interop\Container\Exception\ContainerException as InteropContainerException;
  */
 class ContainerException
     extends Exception
-    implements InteropContainerException
+    implements InteropContainerException # which extends Psr\Container\ContainerExceptionInterface
 {
 }

--- a/src/ContainerFactory.php
+++ b/src/ContainerFactory.php
@@ -3,7 +3,6 @@
 namespace mindplay\unbox;
 
 use Closure;
-use InvalidArgumentException;
 use ReflectionParameter;
 
 /**
@@ -60,7 +59,7 @@ class ContainerFactory extends Configuration
      *
      * @return void
      *
-     * @throws ContainerException
+     * @throws InvalidArgumentException
      */
     public function register($name, $func_or_map_or_type = null, $map = [])
     {
@@ -102,8 +101,6 @@ class ContainerFactory extends Configuration
      * @param mixed  $value
      *
      * @return void
-     *
-     * @throws ContainerException
      */
     public function set($name, $value)
     {
@@ -177,7 +174,7 @@ class ContainerFactory extends Configuration
      *
      * @return void
      *
-     * @throws ContainerException
+     * @throws InvalidArgumentException
      */
     public function configure($name_or_func, $func_or_map = null, $map = [])
     {

--- a/src/InvalidArgumentException.php
+++ b/src/InvalidArgumentException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace mindplay\unbox;
+
+use Interop\Container\Exception\ContainerException;
+
+class InvalidArgumentException
+    extends \InvalidArgumentException
+    implements ContainerException # which extends Psr\Container\ContainerExceptionInterface
+{
+}

--- a/src/NotFoundException.php
+++ b/src/NotFoundException.php
@@ -10,7 +10,7 @@ use Interop\Container\Exception\NotFoundException as InteropNotFoundException;
  */
 class NotFoundException
     extends Exception
-    implements InteropNotFoundException
+    implements InteropNotFoundException # which extends Psr\Container\NotFoundExceptionInterface
 {
     /**
      * @param string $name component name

--- a/src/Reflection.php
+++ b/src/Reflection.php
@@ -3,7 +3,6 @@
 namespace mindplay\unbox;
 
 use Closure;
-use InvalidArgumentException;
 use ReflectionFunction;
 use ReflectionFunctionAbstract;
 use ReflectionMethod;
@@ -27,6 +26,8 @@ abstract class Reflection
      * @param callable|object $callback
      *
      * @return ReflectionFunctionAbstract
+     *
+     * @throws InvalidArgumentException
      */
     public static function createFromCallable($callback)
     {

--- a/test/test.php
+++ b/test/test.php
@@ -1,11 +1,13 @@
 <?php
 
-use Psr\Container\ContainerInterface;
 use mindplay\unbox\Container;
 use mindplay\unbox\ContainerException;
 use mindplay\unbox\ContainerFactory;
 use mindplay\unbox\NotFoundException;
 use mindplay\unbox\Reflection;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 require __DIR__ . '/header.php';
 
@@ -638,6 +640,27 @@ test(
                 "{$pattern_str} should match: " . format($expected)
             );
         }
+    }
+);
+
+test(
+    'has backwards compatibility with legacy PSR-11 interfaces',
+    function () {
+        $factory = new ContainerFactory();
+
+        $container = $factory->createContainer();
+
+        ok($container->get(ContainerInterface::class) instanceof ContainerInterface);
+        ok($container->get(ContainerInterface::class) instanceof \Interop\Container\ContainerInterface);
+
+        ok($container->get(\Interop\Container\ContainerInterface::class) instanceof ContainerInterface);
+        ok($container->get(\Interop\Container\ContainerInterface::class) instanceof \Interop\Container\ContainerInterface);
+
+        ok(new ContainerException() instanceof ContainerExceptionInterface);
+        ok(new ContainerException() instanceof \Interop\Container\Exception\ContainerException);
+
+        ok(new NotFoundException("foo") instanceof NotFoundExceptionInterface);
+        ok(new NotFoundException("foo") instanceof \Interop\Container\Exception\NotFoundException);
     }
 );
 

--- a/test/test.php
+++ b/test/test.php
@@ -1,6 +1,6 @@
 <?php
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use mindplay\unbox\Container;
 use mindplay\unbox\ContainerException;
 use mindplay\unbox\ContainerFactory;


### PR DESCRIPTION
Per #11, this minor release implements forward compatibility with the final PSR-11 package.

Removing support for the legacy PSR-11 package will be a breaking change, and will likely happen in `3.0.0`, so this is the best we can do with a minor release at this time.
