### PR TITLE
Prevent cycles

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -61,7 +61,21 @@ class Container extends Configuration implements ContainerInterface, FactoryInte
 
             $this->active[$name] = true;
 
-            $this->initialize($name);
+            if (isset($this->config[$name])) {
+                foreach ($this->config[$name] as $index => $config) {
+                    $map = $this->config_map[$name][$index];
+
+                    $reflection = Reflection::createFromCallable($config);
+
+                    $params = $this->resolve($reflection->getParameters(), $map);
+
+                    $value = call_user_func_array($config, $params);
+
+                    if ($value !== null) {
+                        $this->values[$name] = $value;
+                    }
+                }
+            }
         }
 
         return $this->values[$name];
@@ -226,31 +240,5 @@ class Container extends Configuration implements ContainerInterface, FactoryInte
     {
         $this->values[$name] = $value;
         $this->active[$name] = true;
-    }
-
-    /**
-     * Internally initialize an active component.
-     *
-     * @param string $name component name
-     *
-     * @return void
-     */
-    private function initialize($name)
-    {
-        if (isset($this->config[$name])) {
-            foreach ($this->config[$name] as $index => $config) {
-                $map = $this->config_map[$name][$index];
-
-                $reflection = Reflection::createFromCallable($config);
-
-                $params = $this->resolve($reflection->getParameters(), $map);
-
-                $value = call_user_func_array($config, $params);
-
-                if ($value !== null) {
-                    $this->values[$name] = $value;
-                }
-            }
-        }
     }
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -58,22 +58,18 @@ class Container extends Configuration implements ContainerInterface, FactoryInte
                 if (isset($this->activations[$name])) {
                     $activations = array_flip($this->activations);
 
-                    ksort($activations, SORT_NUMERIC);
+                    ksort($activations, SORT_NUMERIC); // order by activation depth
 
-                    for ($i=1; $i<count($activations); $i++) {
-                        if ($activations[$i] === $name) {
-                            break;
-                        } else {
-                            unset($activations[$i]);
-                        }
-                    }
+                    $activations = array_slice($activations, array_search($name, $activations, true));
 
-                    $activation_path = implode(" -> ", $activations) . " -> {$name}";
+                    $activations[] = $name;
+
+                    $activation_path = implode(" -> ", $activations);
 
                     throw new ContainerException("Dependency cycle detected: " . $activation_path);
                 }
 
-                $this->activations[$name] = count($this->activations) + 1;
+                $this->activations[$name] = count($this->activations);
 
                 if (isset($this->factory[$name])) {
                     $this->values[$name] = $this->call($this->factory[$name], $this->factory_map[$name]);

--- a/src/Container.php
+++ b/src/Container.php
@@ -48,13 +48,7 @@ class Container extends Configuration implements ContainerInterface, FactoryInte
     {
         if (! isset($this->active[$name])) {
             if (isset($this->factory[$name])) {
-                $factory = $this->factory[$name];
-
-                $reflection = new ReflectionFunction($factory);
-
-                $params = $this->resolve($reflection->getParameters(), $this->factory_map[$name]);
-
-                $this->values[$name] = call_user_func_array($factory, $params);
+                $this->values[$name] = $this->call($this->factory[$name], $this->factory_map[$name]);
             } elseif (! array_key_exists($name, $this->values)) {
                 throw new NotFoundException($name);
             }
@@ -63,13 +57,7 @@ class Container extends Configuration implements ContainerInterface, FactoryInte
 
             if (isset($this->config[$name])) {
                 foreach ($this->config[$name] as $index => $config) {
-                    $map = $this->config_map[$name][$index];
-
-                    $reflection = Reflection::createFromCallable($config);
-
-                    $params = $this->resolve($reflection->getParameters(), $map);
-
-                    $value = call_user_func_array($config, $params);
+                    $value = $this->call($config, $this->config_map[$name][$index]);
 
                     if ($value !== null) {
                         $this->values[$name] = $value;

--- a/src/Container.php
+++ b/src/Container.php
@@ -55,9 +55,9 @@ class Container extends Configuration implements ContainerInterface, FactoryInte
     {
         if (! isset($this->active[$name])) {
             if (isset($this->activations[$name])) {
-                throw new ContainerException(
-                    "Dependency cycle detected: " . implode(" -> ", array_flip($this->activations)) . " -> {$name}"
-                );
+                $activation_path = implode(" -> ", array_flip($this->activations)) . " -> {$name}";
+
+                throw new ContainerException("Dependency cycle detected: " . $activation_path);
             }
 
             $this->activations[$name] = count($this->activations) + 1;
@@ -68,17 +68,17 @@ class Container extends Configuration implements ContainerInterface, FactoryInte
                 throw new NotFoundException($name);
             }
 
-            $this->active[$name] = true;
-
             if (isset($this->config[$name])) {
                 foreach ($this->config[$name] as $index => $config) {
-                    $value = $this->call($config, $this->config_map[$name][$index]);
+                    $value = $this->call($config, [$this->values[$name]] + $this->config_map[$name][$index]);
 
                     if ($value !== null) {
                         $this->values[$name] = $value;
                     }
                 }
             }
+
+            $this->active[$name] = true;
 
             unset($this->activations[$name]);
         }

--- a/test/test.php
+++ b/test/test.php
@@ -740,6 +740,21 @@ test(
             },
             "{Dependency cycle detected: c -> a -> b -> c}i"
         );
+
+        expect(
+            ContainerException::class,
+            "should throw for repeated dependency cycle",
+            function () use ($factory) {
+                $container = $factory->createContainer();
+
+                try {
+                    $container->get("c");
+                } catch (ContainerException $error) {
+                    $container->get("c");
+                }
+            },
+            "{Dependency cycle detected: c -> a -> b -> c}i"
+        );
     }
 );
 
@@ -776,6 +791,34 @@ test(
                 $factory->createContainer()->get("b");
             },
             "{Dependency cycle detected: b -> a -> b}i"
+        );
+    }
+);
+
+test(
+    'can trap deep dependency cycle',
+    function () {
+        $factory = new ContainerFactory();
+
+        $factory->register("a", function ($b) {
+            return "A{$b}";
+        });
+
+        $factory->register("b", function ($c) {
+            return "B{$c}";
+        });
+
+        $factory->register("c", function ($b) {
+            return "C{$b}";
+        });
+
+        expect(
+            ContainerException::class,
+            "should throw for dependency cycle",
+            function () use ($factory) {
+                $factory->createContainer()->get("a");
+            },
+            "{Dependency cycle detected: b -> c -> b}i"
         );
     }
 );


### PR DESCRIPTION
This PR is about detection of dependency cycles.

In the current version, you can create cycles between dependencies, which would cause one of two problems - either:

  1. for direct cycles (e.g. `a -> b -> a`) as well as indirect cycles (e.g. `a -> b -> c -> a`) the container would go into infinite recursion.

  2. for cycles created by configuration (e.g. `a -> b` with configuration of `b` that depends on `a`) the container would produce two instances of the same dependency.

This PR introduces detection of both kinds of cycles and throws a `ContainerException` for both cases, with a useful error message - for example:

> mindplay\unbox\ContainerException: Dependency cycle detected: a -> b -> c -> a in /mnt/c/workspace/staging_project/vendor/mindplay/unbox/src/Container.php on line 69

Before I could fix this, I had to refactor and simlify a bit - this change is best viewed [in isolation](https://github.com/mindplay-dk/unbox/compare/master...refactor) - these changes remove some duplication but should not affect behavior. (and the tests confirm this.)

You can review the changes after refactoring to introduce cycle detection [in isolation](https://github.com/mindplay-dk/unbox/compare/refactor...prevent-cycles) as well - this is the change that introduces the exception. (the added tests double as regression tests, and would previously trigger either infinite recursion or double instances.)

Note that, in order to give meaningful error-messages, the container needs to internally maintain a stack of attempted component activations - I have benchmarked for performance against the previous version, and the impact of this is marginal.

This PR closes #20.
