### PR TITLE
Fix deprecation error

### DIFF
--- a/src/Reflection.php
+++ b/src/Reflection.php
@@ -66,7 +66,7 @@ abstract class Reflection
 
             return $type === null || $type->isBuiltin()
                 ? null // ignore scalar type-hints
-                : $type->__toString();
+                : $type->getName();
         }
 
         if (preg_match(self::ARG_PATTERN, $param->__toString(), $matches) === 1) {


### PR DESCRIPTION
Apparently ReflectionType::__toString() was deprecated as of PHP 7.1. 

See:
https://www.php.net/manual/en/reflectiontype.tostring.php
https://www.php.net/manual/en/class.reflectiontype.php#124658